### PR TITLE
fix: fix multiple CVEs for nginx

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+nginx (1.26.3-3deepin1) UNRELEASED; urgency=medium
+
+  * Fix multiple CVEs for nginx
+    - CVE-2025-53859: Mail: fix STARTTLS handling
+    - CVE-2026-1642: Upstream: detect premature plain text response from
+      SSL backend
+    - CVE-2026-27651: Mail: fixed clearing s->passwd in auth http requests
+    - CVE-2026-27654: Dav: destination length validation for COPY and MOVE
+    - CVE-2026-27784: Mp4: fixed possible integer overflow on 32-bit
+      platforms
+    - CVE-2026-28753: Mail: host validation
+    - CVE-2026-28755: Stream: fixed client certificate validation with OCSP
+    - CVE-2026-32647: Mp4: avoid zero size buffers in output
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 22 Apr 2026 17:52:44 +0800
+
 nginx (1.26.3-3) unstable; urgency=medium
 
   [ Jan Mojžíš ]

--- a/debian/patches/CVE-2025-53859.patch
+++ b/debian/patches/CVE-2025-53859.patch
@@ -1,0 +1,127 @@
+diff --git a/src/mail/ngx_mail_handler.c b/src/mail/ngx_mail_handler.c
+index 1167df3fb..d3be7f3b3 100644
+--- a/src/mail/ngx_mail_handler.c
++++ b/src/mail/ngx_mail_handler.c
+@@ -523,7 +523,7 @@ ngx_mail_starttls_only(ngx_mail_session_t *s, ngx_connection_t *c)
+ ngx_int_t
+ ngx_mail_auth_plain(ngx_mail_session_t *s, ngx_connection_t *c, ngx_uint_t n)
+ {
+-    u_char     *p, *last;
++    u_char     *p, *pos, *last;
+     ngx_str_t  *arg, plain;
+ 
+     arg = s->args.elts;
+@@ -555,7 +555,7 @@ ngx_mail_auth_plain(ngx_mail_session_t *s, ngx_connection_t *c, ngx_uint_t n)
+         return NGX_MAIL_PARSE_INVALID_COMMAND;
+     }
+ 
+-    s->login.data = p;
++    pos = p;
+ 
+     while (p < last && *p) { p++; }
+ 
+@@ -565,7 +565,8 @@ ngx_mail_auth_plain(ngx_mail_session_t *s, ngx_connection_t *c, ngx_uint_t n)
+         return NGX_MAIL_PARSE_INVALID_COMMAND;
+     }
+ 
+-    s->login.len = p++ - s->login.data;
++    s->login.len = p++ - pos;
++    s->login.data = pos;
+ 
+     s->passwd.len = last - p;
+     s->passwd.data = p;
+@@ -583,24 +584,26 @@ ngx_int_t
+ ngx_mail_auth_login_username(ngx_mail_session_t *s, ngx_connection_t *c,
+     ngx_uint_t n)
+ {
+-    ngx_str_t  *arg;
++    ngx_str_t  *arg, login;
+ 
+     arg = s->args.elts;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                    "mail auth login username: \"%V\"", &arg[n]);
+ 
+-    s->login.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[n].len));
+-    if (s->login.data == NULL) {
++    login.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[n].len));
++    if (login.data == NULL) {
+         return NGX_ERROR;
+     }
+ 
+-    if (ngx_decode_base64(&s->login, &arg[n]) != NGX_OK) {
++    if (ngx_decode_base64(&login, &arg[n]) != NGX_OK) {
+         ngx_log_error(NGX_LOG_INFO, c->log, 0,
+             "client sent invalid base64 encoding in AUTH LOGIN command");
+         return NGX_MAIL_PARSE_INVALID_COMMAND;
+     }
+ 
++    s->login = login;
++
+     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                    "mail auth login username: \"%V\"", &s->login);
+ 
+@@ -611,7 +614,7 @@ ngx_mail_auth_login_username(ngx_mail_session_t *s, ngx_connection_t *c,
+ ngx_int_t
+ ngx_mail_auth_login_password(ngx_mail_session_t *s, ngx_connection_t *c)
+ {
+-    ngx_str_t  *arg;
++    ngx_str_t  *arg, passwd;
+ 
+     arg = s->args.elts;
+ 
+@@ -620,18 +623,19 @@ ngx_mail_auth_login_password(ngx_mail_session_t *s, ngx_connection_t *c)
+                    "mail auth login password: \"%V\"", &arg[0]);
+ #endif
+ 
+-    s->passwd.data = ngx_pnalloc(c->pool,
+-                                 ngx_base64_decoded_length(arg[0].len));
+-    if (s->passwd.data == NULL) {
++    passwd.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[0].len));
++    if (passwd.data == NULL) {
+         return NGX_ERROR;
+     }
+ 
+-    if (ngx_decode_base64(&s->passwd, &arg[0]) != NGX_OK) {
++    if (ngx_decode_base64(&passwd, &arg[0]) != NGX_OK) {
+         ngx_log_error(NGX_LOG_INFO, c->log, 0,
+             "client sent invalid base64 encoding in AUTH LOGIN command");
+         return NGX_MAIL_PARSE_INVALID_COMMAND;
+     }
+ 
++    s->passwd = passwd;
++
+ #if (NGX_DEBUG_MAIL_PASSWD)
+     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                    "mail auth login password: \"%V\"", &s->passwd);
+@@ -674,24 +678,26 @@ ngx_int_t
+ ngx_mail_auth_cram_md5(ngx_mail_session_t *s, ngx_connection_t *c)
+ {
+     u_char     *p, *last;
+-    ngx_str_t  *arg;
++    ngx_str_t  *arg, login;
+ 
+     arg = s->args.elts;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                    "mail auth cram-md5: \"%V\"", &arg[0]);
+ 
+-    s->login.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[0].len));
+-    if (s->login.data == NULL) {
++    login.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[0].len));
++    if (login.data == NULL) {
+         return NGX_ERROR;
+     }
+ 
+-    if (ngx_decode_base64(&s->login, &arg[0]) != NGX_OK) {
++    if (ngx_decode_base64(&login, &arg[0]) != NGX_OK) {
+         ngx_log_error(NGX_LOG_INFO, c->log, 0,
+             "client sent invalid base64 encoding in AUTH CRAM-MD5 command");
+         return NGX_MAIL_PARSE_INVALID_COMMAND;
+     }
+ 
++    s->login = login;
++
+     p = s->login.data;
+     last = p + s->login.len;
+ 

--- a/debian/patches/CVE-2026-1642.patch
+++ b/debian/patches/CVE-2026-1642.patch
@@ -1,0 +1,42 @@
+From 784fa05025cb8cd0c770f99bc79d2794b9f85b6e Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Thu, 29 Jan 2026 13:27:32 +0400
+Subject: [PATCH] Upstream: detect premature plain text response from SSL
+ backend.
+
+When connecting to a backend, the connection write event is triggered
+first in most cases.  However if a response arrives quickly enough, both
+read and write events can be triggered together within the same event loop
+iteration.  In this case the read event handler is called first and the
+write event handler is called after it.
+
+SSL initialization for backend connections happens only in the write event
+handler since SSL handshake starts with sending Client Hello.  Previously,
+if a backend sent a quick plain text response, it could be parsed by the
+read event handler prior to starting SSL handshake on the connection.
+The change adds protection against parsing such responses on SSL-enabled
+connections.
+---
+ src/http/ngx_http_upstream.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index df577ad672..cadc74479d 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -2508,6 +2508,15 @@ ngx_http_upstream_process_header(ngx_http_request_t *r, ngx_http_upstream_t *u)
+             return;
+         }
+ 
++#if (NGX_HTTP_SSL)
++        if (u->ssl && c->ssl == NULL) {
++            ngx_log_error(NGX_LOG_ERR, c->log, 0,
++                          "upstream prematurely sent response");
++            ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_ERROR);
++            return;
++        }
++#endif
++
+         u->state->bytes_received += n;
+ 
+         u->buffer.last += n;

--- a/debian/patches/CVE-2026-27651.patch
+++ b/debian/patches/CVE-2026-27651.patch
@@ -1,0 +1,28 @@
+From 0f71dd8ea94ab8c123413b2e465be12a35392e9c Mon Sep 17 00:00:00 2001
+From: Sergey Kandaurov <pluknet@nginx.com>
+Date: Wed, 18 Mar 2026 16:39:37 +0400
+Subject: [PATCH] Mail: fixed clearing s->passwd in auth http requests.
+
+Previously, it was not properly cleared retaining length as part of
+authenticating with CRAM-MD5 and APOP methods that expect to receive
+password in auth response.  This resulted in null pointer dereference
+and worker process crash in subsequent auth attempts with CRAM-MD5.
+
+Reported by Arkadi Vainbrand.
+---
+ src/mail/ngx_mail_auth_http_module.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mail/ngx_mail_auth_http_module.c b/src/mail/ngx_mail_auth_http_module.c
+index 4ca6d6e24d..3e5095a2d2 100644
+--- a/src/mail/ngx_mail_auth_http_module.c
++++ b/src/mail/ngx_mail_auth_http_module.c
+@@ -1328,7 +1328,7 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
+         b->last = ngx_cpymem(b->last, "Auth-Salt: ", sizeof("Auth-Salt: ") - 1);
+         b->last = ngx_copy(b->last, s->salt.data, s->salt.len);
+ 
+-        s->passwd.data = NULL;
++        ngx_str_null(&s->passwd);
+     }
+ 
+     b->last = ngx_cpymem(b->last, "Auth-Protocol: ",

--- a/debian/patches/CVE-2026-27654.patch
+++ b/debian/patches/CVE-2026-27654.patch
@@ -1,0 +1,75 @@
+From a1d18284e0a173c4ef2b28425535d0f640ae0a82 Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Mon, 16 Mar 2026 20:13:03 +0400
+Subject: [PATCH] Dav: destination length validation for COPY and MOVE.
+
+Previously, when alias was used in a location with Dav COPY or MOVE
+enabled, and the destination URI was shorter than the alias, integer
+underflow could happen in ngx_http_map_uri_to_path(), which could
+result in heap buffer overwrite, followed by a possible segfault.
+With some implementations of memcpy(), the segfault could be avoided
+and the overwrite could result in a change of the source or destination
+file names to be outside of the location root.
+
+Reported by Calif.io in collaboration with Claude and Anthropic Research.
+---
+ src/http/modules/ngx_http_dav_module.c | 39 +++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 13 deletions(-)
+
+diff --git a/src/http/modules/ngx_http_dav_module.c b/src/http/modules/ngx_http_dav_module.c
+index cfb98929e9..4619b139a2 100644
+--- a/src/http/modules/ngx_http_dav_module.c
++++ b/src/http/modules/ngx_http_dav_module.c
+@@ -535,19 +535,20 @@ ngx_http_dav_mkcol_handler(ngx_http_request_t *r, ngx_http_dav_loc_conf_t *dlcf)
+ static ngx_int_t
+ ngx_http_dav_copy_move_handler(ngx_http_request_t *r)
+ {
+-    u_char                   *p, *host, *last, ch;
+-    size_t                    len, root;
+-    ngx_err_t                 err;
+-    ngx_int_t                 rc, depth;
+-    ngx_uint_t                overwrite, slash, dir, flags;
+-    ngx_str_t                 path, uri, duri, args;
+-    ngx_tree_ctx_t            tree;
+-    ngx_copy_file_t           cf;
+-    ngx_file_info_t           fi;
+-    ngx_table_elt_t          *dest, *over;
+-    ngx_ext_rename_file_t     ext;
+-    ngx_http_dav_copy_ctx_t   copy;
+-    ngx_http_dav_loc_conf_t  *dlcf;
++    u_char                    *p, *host, *last, ch;
++    size_t                     len, root;
++    ngx_err_t                  err;
++    ngx_int_t                  rc, depth;
++    ngx_uint_t                 overwrite, slash, dir, flags;
++    ngx_str_t                  path, uri, duri, args;
++    ngx_tree_ctx_t             tree;
++    ngx_copy_file_t            cf;
++    ngx_file_info_t            fi;
++    ngx_table_elt_t           *dest, *over;
++    ngx_ext_rename_file_t      ext;
++    ngx_http_dav_copy_ctx_t    copy;
++    ngx_http_dav_loc_conf_t   *dlcf;
++    ngx_http_core_loc_conf_t  *clcf;
+ 
+     if (r->headers_in.content_length_n > 0 || r->headers_in.chunked) {
+         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+@@ -644,6 +645,18 @@ ngx_http_dav_copy_move_handler(ngx_http_request_t *r)
+         return NGX_HTTP_CONFLICT;
+     }
+ 
++    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
++
++    if (clcf->alias
++        && clcf->alias != NGX_MAX_SIZE_T_VALUE
++        && duri.len < clcf->alias)
++    {
++        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
++                      "client sent invalid \"Destination\" header: \"%V\"",
++                      &dest->value);
++        return NGX_HTTP_BAD_REQUEST;
++    }
++
+     depth = ngx_http_dav_depth(r, NGX_HTTP_DAV_INFINITY_DEPTH);
+ 
+     if (depth != NGX_HTTP_DAV_INFINITY_DEPTH) {

--- a/debian/patches/CVE-2026-27784.patch
+++ b/debian/patches/CVE-2026-27784.patch
@@ -1,0 +1,81 @@
+From b23ac73b00313d159a99636c21ef71b828781018 Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Mon, 2 Mar 2026 21:12:34 +0400
+Subject: [PATCH] Mp4: fixed possible integer overflow on 32-bit platforms.
+
+Previously, a 32-bit overflow could happen while validating atom entries
+count.  This allowed processing of an invalid atom with entrires beyond
+its boundaries with reads and writes outside of the allocated mp4 buffer.
+
+Reported by Prabhav Srinath (sprabhav7).
+---
+ src/http/modules/ngx_http_mp4_module.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/http/modules/ngx_http_mp4_module.c b/src/http/modules/ngx_http_mp4_module.c
+index 173d8ad541..678d6296c9 100644
+--- a/src/http/modules/ngx_http_mp4_module.c
++++ b/src/http/modules/ngx_http_mp4_module.c
+@@ -2297,7 +2297,7 @@ ngx_http_mp4_read_stts_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+                    "mp4 time-to-sample entries:%uD", entries);
+ 
+     if (ngx_mp4_atom_data_size(ngx_mp4_stts_atom_t)
+-        + entries * sizeof(ngx_mp4_stts_entry_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(ngx_mp4_stts_entry_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 stts atom too small", mp4->file.name.data);
+@@ -2612,7 +2612,7 @@ ngx_http_mp4_read_stss_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+     atom->last = atom_table;
+ 
+     if (ngx_mp4_atom_data_size(ngx_http_mp4_stss_atom_t)
+-        + entries * sizeof(uint32_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(uint32_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 stss atom too small", mp4->file.name.data);
+@@ -2817,7 +2817,7 @@ ngx_http_mp4_read_ctts_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+     atom->last = atom_table;
+ 
+     if (ngx_mp4_atom_data_size(ngx_mp4_ctts_atom_t)
+-        + entries * sizeof(ngx_mp4_ctts_entry_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(ngx_mp4_ctts_entry_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 ctts atom too small", mp4->file.name.data);
+@@ -2999,7 +2999,7 @@ ngx_http_mp4_read_stsc_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+                    "sample-to-chunk entries:%uD", entries);
+ 
+     if (ngx_mp4_atom_data_size(ngx_mp4_stsc_atom_t)
+-        + entries * sizeof(ngx_mp4_stsc_entry_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(ngx_mp4_stsc_entry_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 stsc atom too small", mp4->file.name.data);
+@@ -3393,7 +3393,7 @@ ngx_http_mp4_read_stsz_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+ 
+     if (size == 0) {
+         if (ngx_mp4_atom_data_size(ngx_mp4_stsz_atom_t)
+-            + entries * sizeof(uint32_t) > atom_data_size)
++            + (uint64_t) entries * sizeof(uint32_t) > atom_data_size)
+         {
+             ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                           "\"%s\" mp4 stsz atom too small",
+@@ -3552,7 +3552,7 @@ ngx_http_mp4_read_stco_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, mp4->file.log, 0, "chunks:%uD", entries);
+ 
+     if (ngx_mp4_atom_data_size(ngx_mp4_stco_atom_t)
+-        + entries * sizeof(uint32_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(uint32_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 stco atom too small", mp4->file.name.data);
+@@ -3768,7 +3768,7 @@ ngx_http_mp4_read_co64_atom(ngx_http_mp4_file_t *mp4, uint64_t atom_data_size)
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, mp4->file.log, 0, "chunks:%uD", entries);
+ 
+     if (ngx_mp4_atom_data_size(ngx_mp4_co64_atom_t)
+-        + entries * sizeof(uint64_t) > atom_data_size)
++        + (uint64_t) entries * sizeof(uint64_t) > atom_data_size)
+     {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "\"%s\" mp4 co64 atom too small", mp4->file.name.data);

--- a/debian/patches/CVE-2026-28753.patch
+++ b/debian/patches/CVE-2026-28753.patch
@@ -1,0 +1,87 @@
+From 6a8513761fb327f67fcc6cfcf1ad216887e2589f Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Thu, 26 Feb 2026 11:52:53 +0400
+Subject: [PATCH] Mail: host validation.
+
+Now host name resolved from client address is validated to only contain
+the characters specified in RFC 1034, Section 3.5.  The validation allows
+to avoid injections when using the resolved host name in auth_http and
+smtp proxy.
+
+Reported by Asim Viladi Oglu Manizada, Colin Warren,
+Xiao Liu (Yunnan University), Yuan Tan (UC Riverside), and
+Bird Liu (Lanzhou University).
+---
+ src/mail/ngx_mail_smtp_handler.c | 45 ++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+diff --git a/src/mail/ngx_mail_smtp_handler.c b/src/mail/ngx_mail_smtp_handler.c
+index 1e26c2c8d7..97bbd70631 100644
+--- a/src/mail/ngx_mail_smtp_handler.c
++++ b/src/mail/ngx_mail_smtp_handler.c
+@@ -13,6 +13,7 @@
+ 
+ 
+ static void ngx_mail_smtp_resolve_addr_handler(ngx_resolver_ctx_t *ctx);
++static ngx_int_t ngx_mail_smtp_validate_host(ngx_str_t *name);
+ static void ngx_mail_smtp_resolve_name(ngx_event_t *rev);
+ static void ngx_mail_smtp_resolve_name_handler(ngx_resolver_ctx_t *ctx);
+ static void ngx_mail_smtp_block_reading(ngx_event_t *rev);
+@@ -127,6 +128,20 @@ ngx_mail_smtp_resolve_addr_handler(ngx_resolver_ctx_t *ctx)
+         return;
+     }
+ 
++    if (ngx_mail_smtp_validate_host(&ctx->name) != NGX_OK) {
++        ngx_log_error(NGX_LOG_ERR, c->log, 0,
++                      "%V resolved to invalid host name \"%V\"",
++                      &c->addr_text, &ctx->name);
++
++        s->host = smtp_tempunavail;
++
++        ngx_resolve_addr_done(ctx);
++
++        ngx_mail_smtp_greeting(s, s->connection);
++
++        return;
++    }
++
+     c->log->action = "in resolving client hostname";
+ 
+     s->host.data = ngx_pstrdup(c->pool, &ctx->name);
+@@ -149,6 +164,36 @@ ngx_mail_smtp_resolve_addr_handler(ngx_resolver_ctx_t *ctx)
+ }
+ 
+ 
++static ngx_int_t
++ngx_mail_smtp_validate_host(ngx_str_t *name)
++{
++    u_char      ch;
++    ngx_uint_t  i;
++
++    if (name->len == 0) {
++        return NGX_DECLINED;
++    }
++
++    for (i = 0; i < name->len; i++) {
++        ch = name->data[i];
++
++        /* allow only characters from RFC 1034, Section 3.5 */
++
++        if ((ch >= 'a' && ch <= 'z')
++            || (ch >= 'A' && ch <= 'Z')
++            || (ch >= '0' && ch <= '9')
++            || ch == '-' || ch == '.')
++        {
++            continue;
++        }
++
++        return NGX_DECLINED;
++    }
++
++    return NGX_OK;
++}
++
++
+ static void
+ ngx_mail_smtp_resolve_name(ngx_event_t *rev)
+ {

--- a/debian/patches/CVE-2026-28755.patch
+++ b/debian/patches/CVE-2026-28755.patch
@@ -1,0 +1,41 @@
+From 78f581487706f2e43eea5a060c516fc4d98090e8 Mon Sep 17 00:00:00 2001
+From: Sergey Kandaurov <pluknet@nginx.com>
+Date: Tue, 17 Mar 2026 19:20:03 +0400
+Subject: [PATCH] Stream: fixed client certificate validation with OCSP.
+
+Check for OCSP status was missed in 581cf2267, resulting
+in a broken validation.
+
+Reported by Mufeed VH of Winfunc Research.
+---
+ src/stream/ngx_stream_ssl_module.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/stream/ngx_stream_ssl_module.c b/src/stream/ngx_stream_ssl_module.c
+index ea0b112b88..85a74ce1d6 100644
+--- a/src/stream/ngx_stream_ssl_module.c
++++ b/src/stream/ngx_stream_ssl_module.c
+@@ -410,6 +410,7 @@ ngx_stream_ssl_handler(ngx_stream_session_t *s)
+     long                        rc;
+     X509                       *cert;
+     ngx_int_t                   rv;
++    const char                 *str;
+     ngx_connection_t           *c;
+     ngx_stream_ssl_srv_conf_t  *sscf;
+ 
+@@ -460,6 +461,15 @@ ngx_stream_ssl_handler(ngx_stream_session_t *s)
+ 
+             X509_free(cert);
+         }
++
++        if (ngx_ssl_ocsp_get_status(c, &str) != NGX_OK) {
++            ngx_log_error(NGX_LOG_INFO, c->log, 0,
++                          "client SSL certificate verify error: %s", str);
++
++            ngx_ssl_remove_cached_session(c->ssl->session_ctx,
++                                       (SSL_get0_session(c->ssl->connection)));
++            return NGX_ERROR;
++        }
+     }
+ 
+     return NGX_OK;

--- a/debian/patches/CVE-2026-32647.patch
+++ b/debian/patches/CVE-2026-32647.patch
@@ -1,0 +1,71 @@
+From a172c880cb51f882a5dc999437e8b3a4f87630cc Mon Sep 17 00:00:00 2001
+From: Roman Arutyunyan <arut@nginx.com>
+Date: Sat, 21 Feb 2026 12:04:36 +0400
+Subject: [PATCH] Mp4: avoid zero size buffers in output.
+
+Previously, data validation checks did not cover the cases when the output
+contained empty buffers.  Such buffers are considered illegal and produce
+"zero size buf in output" alerts.  The change rejects the mp4 files which
+produce such alerts.
+
+Also, the change fixes possible buffer overread and overwrite that could
+happen while processing empty stco and co64 atoms, as reported by
+Pavel Kohout (Aisle Research) and Tim Becker.
+---
+ src/http/modules/ngx_http_mp4_module.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/src/http/modules/ngx_http_mp4_module.c b/src/http/modules/ngx_http_mp4_module.c
+index 445fab1cdf..173d8ad541 100644
+--- a/src/http/modules/ngx_http_mp4_module.c
++++ b/src/http/modules/ngx_http_mp4_module.c
+@@ -901,8 +901,11 @@ ngx_http_mp4_process(ngx_http_mp4_file_t *mp4)
+         }
+     }
+ 
+-    if (end_offset < start_offset) {
+-        end_offset = start_offset;
++    if (end_offset <= start_offset) {
++        ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
++                      "no data between start time and end time in \"%s\"",
++                      mp4->file.name.data);
++        return NGX_ERROR;
+     }
+ 
+     mp4->moov_size += 8;
+@@ -913,7 +916,7 @@ ngx_http_mp4_process(ngx_http_mp4_file_t *mp4)
+ 
+     *prev = &mp4->mdat_atom;
+ 
+-    if (start_offset > mp4->mdat_data.buf->file_last) {
++    if (start_offset >= mp4->mdat_data.buf->file_last) {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "start time is out mp4 mdat atom in \"%s\"",
+                       mp4->file.name.data);
+@@ -3444,7 +3447,7 @@ ngx_http_mp4_update_stsz_atom(ngx_http_mp4_file_t *mp4,
+     if (data) {
+         entries = trak->sample_sizes_entries;
+ 
+-        if (trak->start_sample > entries) {
++        if (trak->start_sample >= entries) {
+             ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                           "start time is out mp4 stsz samples in \"%s\"",
+                           mp4->file.name.data);
+@@ -3619,7 +3622,7 @@ ngx_http_mp4_update_stco_atom(ngx_http_mp4_file_t *mp4,
+         return NGX_ERROR;
+     }
+ 
+-    if (trak->start_chunk > trak->chunks) {
++    if (trak->start_chunk >= trak->chunks) {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "start time is out mp4 stco chunks in \"%s\"",
+                       mp4->file.name.data);
+@@ -3834,7 +3837,7 @@ ngx_http_mp4_update_co64_atom(ngx_http_mp4_file_t *mp4,
+         return NGX_ERROR;
+     }
+ 
+-    if (trak->start_chunk > trak->chunks) {
++    if (trak->start_chunk >= trak->chunks) {
+         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                       "start time is out mp4 co64 chunks in \"%s\"",
+                       mp4->file.name.data);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,11 @@
 0003-define_gnu_source-on-other-glibc-based-platforms.patch
 nginx-fix-pidfile.patch
 nginx-ssl_cert_cb_yield.patch
+CVE-2025-53859.patch
+CVE-2026-1642.patch
+CVE-2026-27651.patch
+CVE-2026-27654.patch
+CVE-2026-27784.patch
+CVE-2026-28753.patch
+CVE-2026-28755.patch
+CVE-2026-32647.patch


### PR DESCRIPTION
- CVE-2025-53859: Mail: fix STARTTLS handling https://nginx.org/download/patch.2025.smtp.txt
- CVE-2026-1642: Upstream: detect premature plain text response from SSL backend https://github.com/nginx/nginx/commit/784fa05025cb8cd0c770f99bc79d2794b9f85b6e
- CVE-2026-27651: Mail: fixed clearing s->passwd in auth http requests https://github.com/nginx/nginx/commit/0f71dd8ea94ab8c123413b2e465be12a35392e9c
- CVE-2026-27654: Dav: destination length validation for COPY and MOVE https://github.com/nginx/nginx/commit/a1d18284e0a173c4ef2b28425535d0f640ae0a82
- CVE-2026-27784: Mp4: fixed possible integer overflow on 32-bit platforms https://github.com/nginx/nginx/commit/b23ac73b00313d159a99636c21ef71b828781018
- CVE-2026-28753: Mail: host validation https://github.com/nginx/nginx/commit/6a8513761fb327f67fcc6cfcf1ad216887e2589f
- CVE-2026-28755: Stream: fixed client certificate validation with OCSP https://github.com/nginx/nginx/commit/78f581487706f2e43eea5a060c516fc4d98090e8
- CVE-2026-32647: Mp4: avoid zero size buffers in output https://github.com/nginx/nginx/commit/a172c880cb51f882a5dc999437e8b3a4f87630cc

Log: Fixed 8 CVEs for nginx

Influence:
1. Build test nginx package
2. Verify patches apply cleanly
3. Test nginx functionality after patch application

fix: 修复 nginx 多个 CVE

- CVE-2025-53859: Mail: 修复 STARTTLS 处理
- CVE-2026-1642: Upstream: 检测 SSL 后端的过早纯文本响应
- CVE-2026-27651: Mail: 修复 auth http 请求中 s->passwd 的清除
- CVE-2026-27654: Dav: COPY 和 MOVE 的目标长度验证
- CVE-2026-27784: Mp4: 修复 32 位平台上的整数溢出
- CVE-2026-28753: Mail: 主机验证
- CVE-2026-28755: Stream: 修复 OCSP 客户端证书验证
- CVE-2026-32647: Mp4: 避免输出中的零大小缓冲区

Log: 修复 8 个 nginx CVE

Influence:
1. 构建测试 nginx 软件包
2. 验证补丁可以干净应用
3. 补丁应用后测试 nginx 功能

repo: nginx #master